### PR TITLE
add quittung.lab.results.folder in app.properties

### DIFF
--- a/src/main/java/de/gematik/demis/entities/ADAPTER_Properties.java
+++ b/src/main/java/de/gematik/demis/entities/ADAPTER_Properties.java
@@ -29,7 +29,7 @@ public enum ADAPTER_Properties implements IProperties {
   IDP_LAB_PROXY_PASSWORD("idp.lab.proxy.password", VALUE_TYPE.PASSWORD, true, "", false, false),
   IDP_LAB_TRUSTSTORE(
       "idp.lab.truststore",
-      VALUE_TYPE.RELATIVE_PATH,
+      VALUE_TYPE.RELATIVE_PATH_FILE,
       false,
       "../config/nginx.truststore",
       true,

--- a/src/main/java/de/gematik/demis/entities/APP_Properties.java
+++ b/src/main/java/de/gematik/demis/entities/APP_Properties.java
@@ -29,6 +29,7 @@ public enum APP_Properties implements IProperties {
   MAINTENANCE_WAITNBMINUTES("maintenance.waitnbminutes", VALUE_TYPE.INT, false, "15", true, false),
   LABOR_LDT_GEBURTSDATUM_FORMAT(
       "labor.ldt.geburtsdatum.format", VALUE_TYPE.STRING, false, "yyyyMMdd", true, false),
+  PDF_FILEPATH("quittung.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/done", true, false)
   ;
 
   private final boolean expertValue;

--- a/src/main/java/de/gematik/demis/entities/APP_Properties.java
+++ b/src/main/java/de/gematik/demis/entities/APP_Properties.java
@@ -7,13 +7,13 @@ import java.util.ResourceBundle;
 public enum APP_Properties implements IProperties {
   DEBUG("debuginfo.enabled", VALUE_TYPE.BOOLEAN, false, "true", true, false),
   FOLDER_INCOMING(
-      "incoming.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/input", true, false),
+      "incoming.lab.results.folder", VALUE_TYPE.RELATIVE_PATH_DIR, false, "../data/input", true, false),
   FOLDER_SUBMITTED(
-      "submitted.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/done", true, false),
+      "submitted.lab.results.folder", VALUE_TYPE.RELATIVE_PATH_DIR, false, "../data/done", true, false),
   FOLDER_ERROR(
-      "error.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/error", true, false),
+      "error.lab.results.folder", VALUE_TYPE.RELATIVE_PATH_DIR, false, "../data/error", true, false),
   FOLDER_QUEUED(
-      "queued.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/queue", true, false),
+      "queued.lab.results.folder", VALUE_TYPE.RELATIVE_PATH_DIR, false, "../data/queue", true, false),
 
   VALID_DEMIS_JOKERS(
       "labor.ldt.valid9901",
@@ -29,7 +29,7 @@ public enum APP_Properties implements IProperties {
   MAINTENANCE_WAITNBMINUTES("maintenance.waitnbminutes", VALUE_TYPE.INT, false, "15", true, false),
   LABOR_LDT_GEBURTSDATUM_FORMAT(
       "labor.ldt.geburtsdatum.format", VALUE_TYPE.STRING, false, "yyyyMMdd", true, false),
-  PDF_FILEPATH("quittung.lab.results.folder", VALUE_TYPE.RELATIVE_PATH, false, "../data/done", true, false)
+  PDF_FILEPATH("quittung.lab.results.folder", VALUE_TYPE.RELATIVE_PATH_DIR, false, "../data/done", true, false)
   ;
 
   private final boolean expertValue;

--- a/src/main/java/de/gematik/demis/entities/VALUE_TYPE.java
+++ b/src/main/java/de/gematik/demis/entities/VALUE_TYPE.java
@@ -2,9 +2,9 @@ package de.gematik.demis.entities;
 
 public enum VALUE_TYPE {
   STRING,
-  PATH,
   BOOLEAN,
-  RELATIVE_PATH,
+  RELATIVE_PATH_FILE,
+  RELATIVE_PATH_DIR,
   STRING_LIST,
   PATH_LIST,
   INT,

--- a/src/main/java/de/gematik/demis/ui/value/editor/RelativPathEditor.java
+++ b/src/main/java/de/gematik/demis/ui/value/editor/RelativPathEditor.java
@@ -23,19 +23,25 @@ public class RelativPathEditor extends AbstractEditor {
   private final JButton dialogJb;
   private String[] fileExtension;
   private String fileExtensionDescription;
+  private boolean selectDir;
 
   public RelativPathEditor(String[] fileExtension) {
-    this();
+    this(false);
     setFileExtensions(fileExtension);
   }
 
-  public RelativPathEditor() {
+  public RelativPathEditor(boolean selectDir) {
+    this.selectDir = selectDir;
     this.setLayout(new BorderLayout());
     relativPath = new JTextField();
     relativPath.setEditable(false);
     add(relativPath, BorderLayout.CENTER);
     dialogJb = new JButton(ImageUtils.loadResizeImage("OPEN_FILE", 15));
-    dialogJb.addActionListener(actionEvent -> selectFile());
+    if (selectDir) {
+      dialogJb.addActionListener(actionEvent -> select(JFileChooser.DIRECTORIES_ONLY));
+    } else {
+      dialogJb.addActionListener(actionEvent -> select(JFileChooser.FILES_ONLY));
+    }
     dialogJb.setEnabled(!isExpertEditor());
     relativPath.setEnabled(!isExpertEditor());
     add(dialogJb, BorderLayout.EAST);
@@ -51,13 +57,13 @@ public class RelativPathEditor extends AbstractEditor {
         fileExtensionDescription.substring(0, fileExtensionDescription.length() - 1);
   }
 
-  private void selectFile() {
+  private void select(int mode) {
     JFileChooser jFileChooser =
         new JFileChooser(
             (lastPath == null
                 ? ConfigurationLoader.getInstance().getPathToMainFolder().toFile().getAbsolutePath()
                 : lastPath));
-    jFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+    jFileChooser.setFileSelectionMode(mode);
     if (fileExtension != null) {
       jFileChooser.setFileFilter(
           new FileFilter() {

--- a/src/main/java/de/gematik/demis/ui/value/editor/ValueTypeEditorFactory.java
+++ b/src/main/java/de/gematik/demis/ui/value/editor/ValueTypeEditorFactory.java
@@ -18,9 +18,10 @@ public class ValueTypeEditorFactory {
         return new PortEditor();
       case STRING_LIST:
         return new StringListEditor();
-      case RELATIVE_PATH:
-      case PATH:
-        return new RelativPathEditor();
+      case RELATIVE_PATH_FILE:
+        return new RelativPathEditor(false);
+      case RELATIVE_PATH_DIR:
+        return new RelativPathEditor(true);
       case STRING:
         return new StringEditor();
       case PASSWORD:

--- a/src/main/resources/DisplayNamesBundle.properties
+++ b/src/main/resources/DisplayNamesBundle.properties
@@ -21,6 +21,7 @@ sendretry.nbseconds=Amount seconds between processing
 sendretry.nbattempts=Maximum amount of trys
 sendretry.nbthreads=Amounnt of concurrent processing trys
 maintenance.waitnbminutes=Amount of minutes to wait inmaintenance state
+quittung.lab.results.folder=Path for PDF receipt
 identifikator=Identificator
 positiveTestergebnisBezeichnungen=List of possible names for positive SARS-CoV-2 Erregernachweistests
 Melder-Person=Facility Manager

--- a/src/main/resources/DisplayNamesBundle_de_DE.properties
+++ b/src/main/resources/DisplayNamesBundle_de_DE.properties
@@ -21,6 +21,7 @@ sendretry.nbseconds=Anzahl Sekunden zwischen zwei Versuchen
 sendretry.nbattempts=Maximale Anzahl der Versuche
 sendretry.nbthreads=Anzahl gleichzeitiger Übertragungen
 maintenance.waitnbminutes=Anzahl Minuten für Pausieren im Wartungsmodus
+quittung.lab.results.folder=Pfad für PDF Quittung
 identifikator=Identifikator
 positiveTestergebnisBezeichnungen=Bezeichner für positive SARS-CoV-2 Erregernachweistests
 Melder-Person=Melder-Person

--- a/src/main/resources/TooltipsBundle.properties
+++ b/src/main/resources/TooltipsBundle.properties
@@ -21,6 +21,7 @@ sendretry.nbseconds=seconds between two trys of processing the LDT to DEMIS
 sendretry.nbattempts=maximum amount of trys before the file is moved to error.lab.results.folder
 sendretry.nbthreads=amounnt of concurrent processing trys
 maintenance.waitnbminutes=amount of minutes before a new try of processing is started, if DEMIS is in maintenance state
+quittung.lab.results.folder=path for PDF receipt\nPredefined with /data/done directory.
 identifikator=correlates to fields 8300/8320 in LDTv2 file. Used for association to laboratory.
 positiveTestergebnisBezeichnungen=list of possible names for positive SARS-CoV-2 Erregernachweistests correlating to field 8480. \n(It is not allowed to process negative tests with DEMIS!)
 Melder-Person=Facility Manager

--- a/src/main/resources/TooltipsBundle_de_DE.properties
+++ b/src/main/resources/TooltipsBundle_de_DE.properties
@@ -20,6 +20,7 @@ labor.ldt.geburtsdatum.format=Format des Geburtsdatums einer betroffenen Person 
 sendretry.nbseconds=Sekunden zwischen zwei Versuchen, das LDT an DEMIS zu übermitteln
 sendretry.nbattempts=Maximale Anzahl der Versuche, bevor die Datei in den Ordner für fehlerhafte Verarbeitung verschoben wird.
 sendretry.nbthreads=Anzahl gleichzeitiger Übertragungen der erneuten Zustellungsversuche.
+quittung.lab.results.folder=Pfad für PDF Quittung.\nVorkonfiguriert mit /data/done Ordner.
 maintenance.waitnbminutes=Anzahl Minuten bevor ein neuer Versuch gestartet wird, die LDTv2-Datei zu verarbeiten, wenn DEMIS sich im Wartungsmodus befindet ist (angekündigte Wartungsfenster).
 identifikator=Entspricht den angegebenen Feldern 8300/8320 in den LDTv2-Datei. Wird benutzt für die Zuordnung zu einer Labor Konfiguration, da  mehrere Labor Konfigurationen unterstützt werden.
 positiveTestergebnisBezeichnungen=Liste möglicher Bezeichner für positive SARS-CoV-2 Erregernachweistests gemäß des Felds 8480. \n(Es dürfen keine Negativtests über DEMIS gemeldet werden!)

--- a/src/test/java/de/gematik/demis/ui/value/editor/RelativPathEditorTest.java
+++ b/src/test/java/de/gematik/demis/ui/value/editor/RelativPathEditorTest.java
@@ -13,7 +13,7 @@ class RelativPathEditorTest {
 
     @Test
     void getSetValue() {
-        RelativPathEditor relativPathEditor = new RelativPathEditor();
+        RelativPathEditor relativPathEditor = new RelativPathEditor(false);
         Assert.assertNotNull(relativPathEditor.getValue());
         Assert.assertEquals("", relativPathEditor.getValue());
         String path = new File("test.file").getAbsolutePath();
@@ -23,7 +23,7 @@ class RelativPathEditorTest {
 
     @Test
     void getViewComponent() {
-        RelativPathEditor relativPathEditor = new RelativPathEditor();
+        RelativPathEditor relativPathEditor = new RelativPathEditor(false);
         Assert.assertNotNull(relativPathEditor.getViewComponent());
         Assert.assertEquals(JTextField.class.toString(), relativPathEditor.getViewComponent().getComponent(0).getClass().toString());
         Assert.assertEquals("", ((JTextField) relativPathEditor.getViewComponent().getComponent(0)).getText());

--- a/src/test/java/de/gematik/demis/ui/value/editor/ValueTypeEditorFactoryTest.java
+++ b/src/test/java/de/gematik/demis/ui/value/editor/ValueTypeEditorFactoryTest.java
@@ -22,14 +22,14 @@ class ValueTypeEditorFactoryTest {
         ValueTypeEditorFactory.createEditor(VALUE_TYPE.STRING_LIST).getClass());
     Assert.assertEquals(
         RelativPathEditor.class,
-        ValueTypeEditorFactory.createEditor(VALUE_TYPE.RELATIVE_PATH).getClass());
+        ValueTypeEditorFactory.createEditor(VALUE_TYPE.RELATIVE_PATH_FILE).getClass());
     Assert.assertEquals(
         StringEditor.class, ValueTypeEditorFactory.createEditor(VALUE_TYPE.STRING).getClass());
     Assert.assertEquals(
         RelativPathListEditor.class,
         ValueTypeEditorFactory.createEditor(VALUE_TYPE.PATH_LIST).getClass());
     Assert.assertEquals(
-        RelativPathEditor.class, ValueTypeEditorFactory.createEditor(VALUE_TYPE.PATH).getClass());
+        RelativPathEditor.class, ValueTypeEditorFactory.createEditor(VALUE_TYPE.RELATIVE_PATH_DIR).getClass());
     Assert.assertEquals(
         UrlEditor.class, ValueTypeEditorFactory.createEditor(VALUE_TYPE.URL).getClass());
     Assert.assertEquals(


### PR DESCRIPTION
Property needed for DEMIS Adapter 1.7.0. 
Default Folder is set to origin path. (../data/done)
If using config of 1.6.5 the property is shown in dialog, but not marked as "unsaved" (same behaviour as birthdate, property is optinal).